### PR TITLE
🛡️ protect against python supply chain attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ At Wander, we use a semantic layer to:
 - Our data warehouse becomes a technical detail so we can focus on building great 
   products.
 
+## Dependency management
+
+This project uses [uv](https://github.com/astral-sh/uv) with `pyproject.toml` for dependency management. A `uv.lock` lockfile is committed to pin exact resolved versions for reproducible environments.
+
+To guard against [Python supply chain attacks](https://pydevtools.com/handbook/how-to/how-to-protect-against-python-supply-chain-attacks-with-uv/), the `[tool.uv]` section in `pyproject.toml` sets a 7-day dependency cooldown via `exclude-newer`. This prevents uv from resolving package versions published within the last week — a window during which most malicious PyPI uploads are detected and yanked before they can reach any environment.
+
 ## License
 MIT
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ init_typed = false
 warn_required_dynamic_aliases = false
 warn_untyped_fields = true
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [build-system]
 requires = ["pdm-backend", "pip"]
 build-backend = "pdm.backend"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to documentation and dependency resolution configuration, with no runtime code impact aside from potentially pinning slightly older package versions during installs.
> 
> **Overview**
> Adds a **Dependency management** section to `README.md` describing use of `uv`, the committed `uv.lock`, and the rationale for a supply-chain mitigation cooldown.
> 
> Updates `pyproject.toml` to configure `uv` with `exclude-newer = "7 days"`, preventing installs from selecting packages published within the last week.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af33f70ebe7b7152dc72e2aa95933e4926c3a85a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->